### PR TITLE
Fix hour calculation for midnight in datadis.py

### DIFF
--- a/edata/providers/datadis.py
+++ b/edata/providers/datadis.py
@@ -403,7 +403,14 @@ class DatadisConnector:
         for i in response.get("timeCurve", []):
             if "consumptionKWh" in i:
                 if all(k in i for k in GET_CONSUMPTION_DATA_MANDATORY_FIELDS):
-                    hour = str(int(i["time"].split(":")[0]) - 1)
+                    raw_hour = int(i["time"].split(":")[0])
+                    if raw_hour == 0:
+                        hour = "23"
+                        i["date"] = (datetime.strptime(i["date"], "%Y/%m/%d") -
+                    timedelta(days=1)).strftime("%Y/%m/%d")
+                    else:
+                        hour = str(raw_hour - 1)
+                    # hour = str(int(i["time"].split(":")[0]) - 1)
                     date_as_dt = datetime.strptime(
                         f"{i['date']} {hour.zfill(2)}:00", "%Y/%m/%d %H:%M"
                     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "e-data"
+name = "edata"
 version = "2.0.0"
 description = "Python library for managing spanish energy data from various web providers"
 readme = "README.md"


### PR DESCRIPTION
Adjust hour calculation for midnight cases and update date accordingly.
The Datadis API has changed the hour format from 01:00-24:00 to 00:00-23:00 (at least for distributor 8 = IDE).

This is related to https://github.com/uvejota/homeassistant-edata/issues/310