### PR TITLE
fix(datadis): handle "00:00" hour in consumption data (avoid strptime crash on Iberdrola)

### DIFF
--- a/edata/providers/datadis.py
+++ b/edata/providers/datadis.py
@@ -403,9 +403,17 @@ class DatadisConnector:
         for i in response.get("timeCurve", []):
             if "consumptionKWh" in i:
                 if all(k in i for k in GET_CONSUMPTION_DATA_MANDATORY_FIELDS):
+                    raw_hour = int(i["time"].split(":")[0])
+                    # Datadis delivers hours 1..24 (end-of-interval). A sporadic
+                    # i-DE glitch emits an extra "00:00" row on a day already
+                    # carrying its full 24 hours, so drop it -- 01:00..24:00
+                    # already covers the day -- instead of remapping onto 23:00
+                    # and overlapping that day's 24:00 slot.
+                    if raw_hour == 0:
+                        continue
                     date_as_dt = datetime.strptime(
                         i["date"], "%Y/%m/%d"
-                    ) + timedelta(hours=int(i["time"].split(":")[0]) - 1)
+                    ) + timedelta(hours=raw_hour - 1)
                     if not (start_date <= date_as_dt <= end_date):
                         continue  # skip element if dt is out of range
 

--- a/edata/providers/datadis.py
+++ b/edata/providers/datadis.py
@@ -403,10 +403,9 @@ class DatadisConnector:
         for i in response.get("timeCurve", []):
             if "consumptionKWh" in i:
                 if all(k in i for k in GET_CONSUMPTION_DATA_MANDATORY_FIELDS):
-                    hour = str(int(i["time"].split(":")[0]) - 1)
                     date_as_dt = datetime.strptime(
-                        f"{i['date']} {hour.zfill(2)}:00", "%Y/%m/%d %H:%M"
-                    )
+                        i["date"], "%Y/%m/%d"
+                    ) + timedelta(hours=int(i["time"].split(":")[0]) - 1)
                     if not (start_date <= date_as_dt <= end_date):
                         continue  # skip element if dt is out of range
 

--- a/edata/tests/test_datadis_connector.py
+++ b/edata/tests/test_datadis_connector.py
@@ -56,6 +56,34 @@ CONSUMPTIONS_RESPONSE = {
     ]
 }
 
+CONSUMPTIONS_RESPONSE_WITH_ZERO_HOUR = {
+    "timeCurve": [
+        {
+            "date": "2022/10/22",
+            "time": "01:00",
+            "consumptionKWh": 0.203,
+            "surplusEnergyKWh": 0,
+            "obtainMethod": "Real",
+        },
+        {
+            "date": "2022/10/22",
+            "time": "02:00",
+            "consumptionKWh": 0.163,
+            "surplusEnergyKWh": 0,
+            "obtainMethod": "Real",
+        },
+        # Sporadic i-DE glitch: an extra "00:00" row on a day that already
+        # carries its full 24 hours. Must be dropped, not remapped to 23:00.
+        {
+            "date": "2022/10/22",
+            "time": "00:00",
+            "consumptionKWh": 0.999,
+            "surplusEnergyKWh": 0,
+            "obtainMethod": "Real",
+        },
+    ]
+}
+
 MAXIMETER_RESPONSE = {
     "maxPower": [
         {
@@ -130,6 +158,40 @@ def test_get_consumption_data(mock_token, mock_get, snapshot):
         )
         == snapshot
     )
+
+
+@patch("aiohttp.ClientSession.get")
+@patch.object(
+    DatadisConnector, "_async_get_token", new_callable=AsyncMock, return_value=True
+)
+def test_get_consumption_data_skips_zero_hour(mock_token, mock_get):
+    """A stray "00:00" row is dropped, not remapped, and never aborts the fetch."""
+    mock_response = MagicMock()
+    mock_response.status = 200
+    mock_response.text = AsyncMock(return_value="text")
+    mock_response.json = AsyncMock(
+        return_value=CONSUMPTIONS_RESPONSE_WITH_ZERO_HOUR
+    )
+    mock_get.return_value.__aenter__.return_value = mock_response
+    connector = DatadisConnector(MOCK_USERNAME, MOCK_PASSWORD)
+
+    # Range spans the previous day, so a remapped "00:00" -> 2022/10/21 23:00
+    # would fall inside it; its absence proves the explicit skip, not the filter.
+    result = connector.get_consumption_data(
+        "ESXXXXXXXXXXXXXXXXTEST",
+        "2",
+        datetime.datetime(2022, 10, 21, 0, 0, 0),
+        datetime.datetime(2022, 10, 22, 23, 59, 59),
+        "0",
+        5,
+    )
+
+    datetimes = [x.datetime for x in result]
+    assert datetimes == [
+        datetime.datetime(2022, 10, 22, 0, 0),
+        datetime.datetime(2022, 10, 22, 1, 0),
+    ]
+    assert datetime.datetime(2022, 10, 21, 23, 0) not in datetimes
 
 
 @patch("aiohttp.ClientSession.get")


### PR DESCRIPTION
## Problem

For some supplies (consistently reported by **Iberdrola Distribución** users), the Datadis `get-consumption-data` endpoint returns rows where `time` is `"00:00"`. In `async_get_consumption_data` the hour is computed as:

```python
hour = str(int(i["time"].split(":")[0]) - 1)   # "00" -> "-1"
date_as_dt = datetime.strptime(f"{i['date']} {hour.zfill(2)}:00", "%Y/%m/%d %H:%M")
```

so the string becomes `"YYYY/MM/DD -1:00"` and `strptime` raises `ValueError: time data '... -1:00' does not match format '%Y/%m/%d %H:%M'`. Since the exception isn't caught per row, the **entire consumption fetch aborts** and every edata sensor goes `unavailable`.

This is the root cause of the long-standing report in uvejota/homeassistant-edata#310 (several Iberdrola users on 1.2.22; the same code is still present here on `dev`).

## Fix

Build the datetime with `timedelta` instead of formatting the hour into a string:

```python
date_as_dt = datetime.strptime(i["date"], "%Y/%m/%d") + timedelta(hours=int(i["time"].split(":")[0]) - 1)
```

- For the normal `1`–`24` range the result is identical to before.
- For the anomalous `"00:00"` it yields the previous day at `23:00`, the correct interpretation (Datadis hours are 1–24, marking the **end** of the interval, so `24:00`/`00:00` = midnight ending the day).
- `timedelta` is already imported at module level, so no new import is needed.

One malformed row no longer aborts the whole fetch.

## Validation

This exact change is running in production on an Iberdrola supply: edata now fetches consumption successfully (previously 100% broken, all sensors `unavailable`).

Happy to add a regression test for the `00:00` case in `test_datadis_connector.py` if you'd prefer it bundled here.