### PR TITLE
fix(data_service): clamp pvpc fetch window to avoid REData 400

### DIFF
--- a/edata/services/data_service.py
+++ b/edata/services/data_service.py
@@ -316,7 +316,9 @@ class DataService:
             # end date out of bounds
             return False
         if _pvpc_dt := await self._get_last_pvpc_dt():
-            start = _pvpc_dt + timedelta(hours=1)
+            # keep within the fetchable window even if the last stored price is
+            # older than a month, otherwise REData rejects the range with a 400
+            start = max(_pvpc_dt + timedelta(hours=1), min_date)
             if start >= end:
                 _LOGGER.info("%s pvpc prices are already synced", self._scups)
                 # data is already synced

--- a/edata/tests/test_services.py
+++ b/edata/tests/test_services.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta
 import json
 import os
 from tempfile import gettempdir
@@ -7,6 +8,7 @@ import pytest
 import pytest_asyncio
 from syrupy.assertion import SnapshotAssertion
 
+from edata.core.utils import get_day
 from edata.models.bill import BillingRules
 from edata.models.data import Energy, Power
 from edata.models.supply import Contract, Supply
@@ -211,3 +213,22 @@ async def test_clear_bills(populated_data_service, energy, storage_dir):
     assert len(await bs.get_bills("hour")) == 0
     assert len(await bs.get_bills(type_="day")) == 0
     assert len(await bs.get_bills(type_="month")) == 0
+
+
+@pytest.mark.asyncio
+async def test_update_pvpc_clamps_range_to_min_date(populated_data_service):
+    ds = populated_data_service
+    now = datetime.now()
+    stale_dt = now - timedelta(days=90)
+
+    with (
+        patch.object(ds, "_get_last_pvpc_dt", AsyncMock(return_value=stale_dt)),
+        patch.object(
+            ds.redata, "async_get_realtime_prices", AsyncMock(return_value=[])
+        ) as mock_fetch,
+    ):
+        await ds.update_pvpc(now - timedelta(days=365), now)
+
+    mock_fetch.assert_awaited_once()
+    called_start = mock_fetch.await_args.args[0]
+    assert called_start >= get_day(now) - timedelta(days=28)


### PR DESCRIPTION
update_pvpc reset start to the last stored pvpc timestamp without re-applying the 28-day window bound, so resuming after a gap requested more than a month of data and REData rejected it with HTTP 400 (pvpc then stopped updating). Clamp start to min_date after adopting the last pvpc timestamp; REData cannot serve older data anyway.