### PR TITLE
perf: process statistics one month at a time to bound memory

### DIFF
--- a/edata/core/utils.py
+++ b/edata/core/utils.py
@@ -1,10 +1,12 @@
 """Collection of utilities."""
 
 import logging
-from datetime import datetime
+import typing
+from datetime import datetime, timedelta
 from functools import lru_cache
 from pathlib import Path
 
+from dateutil.relativedelta import relativedelta
 import holidays
 
 from edata.models.supply import Contract
@@ -75,6 +77,27 @@ def get_day(dt: datetime) -> datetime:
     """Return a datetime that represents the day start for a provided datetime."""
 
     return dt.replace(hour=0, minute=0, second=0, microsecond=0)
+
+
+def iter_month_windows(
+    start: datetime, end: datetime
+) -> typing.Iterator[tuple[datetime, datetime]]:
+    """Yield contiguous ``(window_start, window_end)`` pairs, one calendar month each.
+
+    Windows are non-overlapping and cover ``[start, end]`` inclusively; the first
+    starts at ``start`` and the last ends at ``end``. Iterating a month at a time
+    keeps the working set bounded to a single month regardless of history length.
+    """
+
+    if end < start:
+        return
+
+    win_start = start
+    while win_start <= end:
+        next_month = get_month(win_start) + relativedelta(months=1)
+        win_end = min(next_month - timedelta(microseconds=1), end)
+        yield win_start, win_end
+        win_start = next_month
 
 
 def redacted_cups(cups: str) -> str:

--- a/edata/services/bill_service.py
+++ b/edata/services/bill_service.py
@@ -16,6 +16,7 @@ from edata.core.utils import (
     get_day,
     get_month,
     get_tariff,
+    iter_month_windows,
     redacted_cups,
 )
 from edata.database.controller import EdataDB
@@ -107,31 +108,39 @@ class BillService:
         # fetch contracts
         contracts = await self._get_contracts()
 
-        # fetch and filter energy items
-        energy = await self._get_energy()
-
-        _LOGGER.debug("%s compiling missing hourly bills", self._scups)
         if is_pvpc:
-            pvpc = await self._get_pvpc()
             billing_rules = PVPCBillingRules(**billing_rules.model_dump())
-            bills = await asyncio.to_thread(
-                self.simulate_pvpc, contracts, energy, pvpc, billing_rules
-            )
             confighash = f"pvpc-{hash(billing_rules.model_dump_json())}"
         else:
-            bills = await asyncio.to_thread(
-                self.simulate_custom, contracts, energy, billing_rules
-            )
             confighash = f"custom-{hash(billing_rules.model_dump_json())}"
 
-        _LOGGER.debug("%s pushing hourly bills", self._scups)
-        await self.db.add_bill_list(
-            cups=self._cups,
-            type_="hour",
-            confhash=confighash,
-            complete=True,
-            bill=bills,
-        )
+        # compile and persist hourly bills one month at a time so the energy
+        # (and simulated bills) held in memory stay bounded to a single month
+        for win_start, win_end in iter_month_windows(start, end):
+            energy = await self._get_energy(win_start, win_end)
+            if not energy:
+                continue
+
+            _LOGGER.debug(
+                "%s compiling hourly bills for %s..%s", self._scups, win_start, win_end
+            )
+            if is_pvpc:
+                pvpc = await self._get_pvpc(win_start, win_end)
+                bills = await asyncio.to_thread(
+                    self.simulate_pvpc, contracts, energy, pvpc, billing_rules
+                )
+            else:
+                bills = await asyncio.to_thread(
+                    self.simulate_custom, contracts, energy, billing_rules
+                )
+
+            await self.db.add_bill_list(
+                cups=self._cups,
+                type_="hour",
+                confhash=confighash,
+                complete=True,
+                bill=bills,
+            )
 
         _LOGGER.debug("%s updating daily and monthly bills", self._scups)
         await self.update_statistics(start, end)
@@ -171,10 +180,11 @@ class BillService:
         )
 
     async def update_statistics(self, start: datetime, end: datetime):
-        """Update the statistics during a period."""
+        """Update the statistics during a period, one month at a time."""
 
-        await self._update_daily_statistics(start, end)
-        await self._update_monthly_statistics(start, end)
+        for win_start, win_end in iter_month_windows(start, end):
+            await self._update_daily_statistics(win_start, win_end)
+            await self._update_monthly_statistics(win_start, win_end)
 
     async def _update_daily_statistics(self, start: datetime, end: datetime) -> None:
         """Update daily statistics within a date range."""
@@ -306,21 +316,17 @@ class BillService:
     ) -> list[Bill]:
         """Compile bills assuming PVPC billing."""
 
-        energy_dt = [x.datetime for x in energy]
-        pvpc_dt = [x.datetime for x in pvpc]
+        # reduce computation to timestamps present in both series and covered
+        # by a contract (set membership instead of nested list scans)
+        common_dt = {x.datetime for x in energy} & {x.datetime for x in pvpc}
+        valid_dt = {
+            dt
+            for dt in common_dt
+            if any(c.date_start <= dt <= c.date_end for c in contracts)
+        }
 
-        # reduce computation range to valid periods
-        pvpc_valid_dt = []
-        for contract in contracts:
-            for dt in pvpc_dt:
-                if dt in pvpc_valid_dt:
-                    continue
-                if contract.date_start <= dt <= contract.date_end:
-                    pvpc_valid_dt.append(dt)
-        pvpc_valid_dt = [x for x in pvpc_valid_dt if x in energy_dt]
-
-        e = {x.datetime: x for x in energy if x.datetime in pvpc_valid_dt}
-        p = {x.datetime: x for x in pvpc if x.datetime in pvpc_valid_dt}
+        e = {x.datetime: x for x in energy if x.datetime in valid_dt}
+        p = {x.datetime: x for x in pvpc if x.datetime in valid_dt}
         b: dict[datetime, Bill] = {}
 
         for dt in e.keys():

--- a/edata/services/data_service.py
+++ b/edata/services/data_service.py
@@ -11,7 +11,14 @@ from tempfile import gettempdir
 
 from dateutil import relativedelta
 
-from edata.core.utils import get_db_path, get_day, get_month, get_tariff, redacted_cups
+from edata.core.utils import (
+    get_db_path,
+    get_day,
+    get_month,
+    get_tariff,
+    iter_month_windows,
+    redacted_cups,
+)
 from edata.database.controller import EdataDB
 from edata.models import Contract, Energy, Power, Statistics, Supply
 from edata.models.bill import EnergyPrice
@@ -332,10 +339,15 @@ class DataService:
         return False
 
     async def update_statistics(self, start: datetime, end: datetime) -> None:
-        """Update the statistics during a period."""
+        """Update the statistics during a period, one month at a time.
 
-        await self._update_daily_statistics(start, end)
-        await self._update_monthly_statistics(start, end)
+        Iterating monthly windows keeps the energy loaded for compilation bounded
+        to a single month instead of the whole history.
+        """
+
+        for win_start, win_end in iter_month_windows(start, end):
+            await self._update_daily_statistics(win_start, win_end)
+            await self._update_monthly_statistics(win_start, win_end)
 
     async def _update_daily_statistics(self, start: datetime, end: datetime) -> None:
         """Update daily statistics within a date range."""

--- a/edata/tests/test_utils.py
+++ b/edata/tests/test_utils.py
@@ -1,0 +1,60 @@
+"""Tests for edata.core.utils helpers."""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from edata.core.utils import get_month, iter_month_windows
+
+
+def _assert_windows_valid(
+    windows: list[tuple[datetime, datetime]],
+    start: datetime,
+    end: datetime,
+) -> None:
+    """Assert windows tile [start, end] contiguously, one calendar month each."""
+    assert windows[0][0] == start
+    assert windows[-1][1] == end
+    for win_start, win_end in windows:
+        assert win_start <= win_end
+        # a window never straddles a calendar-month boundary
+        assert get_month(win_start) == get_month(win_end)
+    for (_, prev_end), (next_start, _) in zip(windows, windows[1:], strict=False):
+        # contiguous and non-overlapping
+        assert next_start == prev_end + timedelta(microseconds=1)
+
+
+@pytest.mark.parametrize(
+    ("start", "end", "expected_len"),
+    [
+        # sub-month range collapses to a single window
+        (datetime(2023, 1, 5), datetime(2023, 1, 20), 1),
+        # spans three calendar months
+        (datetime(2023, 1, 15), datetime(2023, 3, 10), 3),
+        # exact month boundaries
+        (datetime(2023, 1, 1), datetime(2023, 2, 28, 23, 59, 59), 2),
+        # crosses a year boundary
+        (datetime(2022, 12, 20), datetime(2023, 2, 1), 3),
+        # spring-forward DST month is handled like any other (naive datetimes)
+        (datetime(2023, 3, 1), datetime(2023, 4, 15), 2),
+    ],
+    ids=["sub-month", "three-months", "exact-boundaries", "year-boundary", "dst-month"],
+)
+def test_iter_month_windows_tiles_range(
+    start: datetime, end: datetime, expected_len: int
+) -> None:
+    """Windows cover the range contiguously, one calendar month at a time."""
+    windows = list(iter_month_windows(start, end))
+    assert len(windows) == expected_len
+    _assert_windows_valid(windows, start, end)
+
+
+def test_iter_month_windows_single_instant() -> None:
+    """A zero-length range yields exactly one window covering that instant."""
+    moment = datetime(2023, 6, 15, 10, 30)
+    assert list(iter_month_windows(moment, moment)) == [(moment, moment)]
+
+
+def test_iter_month_windows_empty_when_end_before_start() -> None:
+    """An inverted range yields no windows."""
+    assert list(iter_month_windows(datetime(2023, 2, 1), datetime(2023, 1, 1))) == []


### PR DESCRIPTION
## Summary

Follow-up to #30. That fix stopped the recorder from re-importing the entire history on every per-sync refresh, but the **full-rebuild paths** (first setup, soft reset, full import, billing rebuild) still loaded and processed the whole history in one shot — so the transient working set grew linearly with history length and could exhaust RAM on large meters (15-min data and/or 3+ years).

This processes the range in **monthly windows** so peak memory is bounded to roughly one month of data regardless of history length.

## Changes

- Add `iter_month_windows(start, end)` — yields contiguous, non-overlapping, month-aligned `(start, end)` pairs.
- `DataService.update_statistics` and `BillService.update` / `update_statistics` iterate those windows, loading only one month of energy/bills per step.
- `BillService.update` compiles and persists hourly bills per window, so `simulate_*` no longer holds the whole history in memory.
- `simulate_pvpc`: replace the `O(contracts × pvpc)` nested list-membership filtering with a set intersection.

Monthly windows align with the existing day/month aggregation boundaries, so aggregate results are unchanged.

## Tests

- New `edata/tests/test_utils.py` covering `iter_month_windows` (sub-month, multi-month, exact/year/DST boundaries, single instant, inverted range).
- Full suite green (24 passed).

## Notes

- Diagnosed and verified with synthetic data only.
- Pairs with a matching homeassistant-edata change that windows the recorder statistics builders; that side pins the `e-data` build this PR produces once it merges to `dev` and CI publishes a new `.devN`.